### PR TITLE
log actual queries for better analysis

### DIFF
--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,29 +1,50 @@
 require 'spec_helper'
 
 describe QueryDiet::Logger do
-
-  before :each do
+  before do
     QueryDiet::Logger.reset
   end
 
-  describe 'count' do
+  describe "#reset" do
+    it "should reset count/time/queries" do
+      QueryDiet::Logger.count.should == 0
+      QueryDiet::Logger.time.should == 0
+      QueryDiet::Logger.queries.should == []
 
+      Benchmark.should_receive(:realtime).and_return(5)
+      Movie.create
+
+      QueryDiet::Logger.count.should > 0
+      QueryDiet::Logger.time.should > 0
+      QueryDiet::Logger.queries.size.should > 0
+    end
+  end
+
+  describe "#count" do
     it "should return the number of queries since the last reset" do
       Movie.create
       Movie.create
       QueryDiet::Logger.count.should == 2
     end
-
   end
 
-  describe 'time' do
-
+  describe "#time" do
     it "should return the number of miliseconds spent running database queries since the last reset" do
       Benchmark.should_receive(:realtime).and_return(5)
       Movie.create
       QueryDiet::Logger.time.should == 5000
     end
-
   end
 
+  describe "#queries" do
+    it "should return the queries since last reset" do
+      Benchmark.should_receive(:realtime).and_return(5.1234)
+      Movie.create
+      QueryDiet::Logger.queries.size.should == 1
+      query = QueryDiet::Logger.queries.first
+      query.size.should == 2
+      query[0].should include("INSERT INTO \"movies\"")
+      query[1].should == 5.1234
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'spec/rails'
 silence_warnings {RAILS_ENV = ENV['RAILS_ENV']}
 
 # Run the migrations
+ActiveRecord::Migration.verbose = false
 ActiveRecord::Migrator.migrate("#{Rails.root}/db/migrate")
 
 Spec::Runner.configure do |config|


### PR DESCRIPTION
we use query_diet in test, but 10 queries expected, but was 11 is not very helpful in debugging,
with these queries we can see what got added + they might be useful for an expanded display -> what queries got run?
