### PR TITLE
Improve support for PostgreSQL adapter

### DIFF
--- a/lib/query_diet/logger.rb
+++ b/lib/query_diet/logger.rb
@@ -42,7 +42,7 @@ module QueryDiet
       private
 
       def log_query?(query)
-        query =~ /^(select|create|update|delete|insert)\b/i
+        query =~ /^\s*(select|create|update|delete|insert)\b/i
       end
     end
 

--- a/lib/query_diet/logger.rb
+++ b/lib/query_diet/logger.rb
@@ -10,15 +10,24 @@ module QueryDiet
       end
 
       def log(query)
-        if paused?
-          yield
-        else
-          result = nil
-          time = Benchmark.realtime do
-            result = yield
+        time = 0
+
+        begin
+          if paused?
+            yield
+          else
+            result = nil
+            time = Benchmark.realtime do
+              result = yield
+            end
+            result
           end
+
+        ensure
+          # We need this in an ensure because it's possible the adapter will
+          # include a break, in which case we otherwise wouldn't get past the
+          # call to Benchmark#realtime.
           queries << [query, time] if log_query?(query)
-          result
         end
       end
 


### PR DESCRIPTION
QueryDiet was working great for me at first, using SQLite in development. Eventually I switched to Postgres (to mirror what my app was using in production—on Heroku), and suddently QueryDiet was repeatedly reporting 0 queries.

Digging into the issue, I noticed two things. First, the Postgres adapter for ActiveRecord seems to insert some leading space at the beginning of the query, which caused `QueryDiet::Logger#log_query?` to return `false` for actual queries. Second, there must be a `break` somewhere in the bowels of the adapter's logging code, because I determined (from super not-hacky `puts` debugging!) that the code was getting to the `Benchmark.realtime` call but not past it. (If I'm not mistaken, this means that a `break` somewhere in the block executed by `yield` was causing the method to return early.)

So this commit updates the pattern matched by `log_query?` and puts the query storage in an `ensure` to force it to work.

I realize this is a bit crap without any tests, but I was feeling lazy and hoping you'd write them for me. If you want me to add them, let me know and I'll do it eventually :)