### PR TITLE
make rails 5 compatible

### DIFF
--- a/lib/query_diet/active_record_ext.rb
+++ b/lib/query_diet/active_record_ext.rb
@@ -6,6 +6,7 @@ ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
     end
   end
 
-  alias_method_chain :log, :query_diet
+  alias_method :log_without_query_diet, :log
+  alias_method :log, :log_with_query_diet
 
 end

--- a/lib/query_diet/rack/reset_logger.rb
+++ b/lib/query_diet/rack/reset_logger.rb
@@ -18,9 +18,9 @@ end
 if defined?(Rails::Railtie)
   class QueryDiet::Railtie < Rails::Railtie
     initializer 'query_diet.insert_middleware' do |app|
-      app.config.middleware.use 'QueryDiet::Rack::ResetLogger'
+      app.config.middleware.use QueryDiet::Rack::ResetLogger
     end
   end
 else
-  ActionController::Dispatcher.middleware.use('QueryDiet::Rack::ResetLogger')
+  ActionController::Dispatcher.middleware.use(QueryDiet::Rack::ResetLogger)
 end


### PR DESCRIPTION
alias_method_chain is gone ... simple patch to keep things working

@henning-koch 