### PR TITLE
Allow to pass in a nonce to fulfill the CSP in development (closes #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 
 ## Unreleased
+### Compatible changes
+### Breaking changes
+
+## 0.7.0 2020-09-24
+### Compatible changes
+
+* Add #23: Allow to pass in a nonce to fulfill the CSP in development. It is used as follows:
+  ```
+  = query_diet_widget(nonce: true) if Rails.env.development?
+  ```
 
 ### Compatible changes
+
 - This CHANGELOG file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
-
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
-
 ## Unreleased
 ### Compatible changes
-### Breaking changes
-
 ## 0.7.0 2020-09-24
 ### Compatible changes
-
-* Add #23: Allow to pass in a nonce to fulfill the CSP in development. It is used as follows:
-  ```
-  = query_diet_widget(nonce: true) if Rails.env.development?
-  ```
-
-### Compatible changes
-
-- This CHANGELOG file.
+- Added: CSP support for query diet widget (#23)
+- Added this CHANGELOG file.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ To change the default, simply pass them to the `query_diet_widget` helper:
 <%= query_diet_widget(:bad_count => 4, :bad_time => 2000) %>
 ```
 
+### Content Security Policy
+
+You can pass whether to use a nonce for style and script tags. This option is per default `false`.
+
+```Erb
+<%= query_diet_widget(:nonce => true) if Rails.env.development? %>
+```
+
+In your content security policy initializer of the project you should set the nonce to those directives:
+```Erb
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src style-src]
+```
+
+When you do not want to use a nonce, but use a style tag, for example, you could use `unsafe_inline`:
+```Erb
+Rails.application.config.content_security_policy do |policy|
+  policy.style_src   :self, :unsafe_inline
+```
 
 ### Rails compatibility
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ To change the default, simply pass them to the `query_diet_widget` helper:
 
 ### Content Security Policy
 
-You can pass whether to use a nonce for style and script tags. This option is per default `false`.
+You can pass whether to use a nonce for style and script tags.
+Note that the key must be a symbol like in the example below, otherwise it defaults to `false`.
 
 ```Erb
 <%= query_diet_widget(:nonce => true) if Rails.env.development? %>

--- a/lib/query_diet/widget.rb
+++ b/lib/query_diet/widget.rb
@@ -52,10 +52,11 @@ module QueryDiet
     end
 
     module Helper
-      def query_diet_widget(options = { 'nonce' => false })
-        with_nonce = options.fetch('nonce', options[:nonce])
-        nonce = with_nonce ? content_security_policy_nonce : nil
-        nonce_attribute = nonce ? " nonce=\"#{nonce}\"" : ''
+      def query_diet_widget(options = {})
+        default_html_options = {:nonce => false}
+        options = options.reverse_merge(default_html_options)
+
+        nonce_attribute = options.fetch(:nonce) ? " nonce=\"#{content_security_policy_nonce}\"" : ''
 
         html = Widget.css(nonce_attribute) + Widget.html(options) + Widget.js(nonce_attribute)
         html.respond_to?(:html_safe) ? html.html_safe : html


### PR DESCRIPTION
You can pass whether to use a nonce for style and script tags. This option is per default `false`. It can be used as follows:
```
<%= query_diet_widget(:nonce => true) if Rails.env.development? %>
```