### PR TITLE
Fix Rails 8.1+ compatibility replacing Benchmark with Process.clock_gettime

### DIFF
--- a/lib/query_diet/logger.rb
+++ b/lib/query_diet/logger.rb
@@ -1,5 +1,3 @@
-require 'benchmark'
-
 module QueryDiet
   class Logger
     DEFAULT_OPTIONS = { :bad_count => 8, :bad_time => 5000 }
@@ -16,9 +14,9 @@ module QueryDiet
           yield
         else
           result = nil
-          time = Benchmark.realtime do
-            result = yield
-          end
+          start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          result = yield
+          time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
           queries << [query, time] if log_query?(query)
           result
         end

--- a/spec/query_diet/logger_spec.rb
+++ b/spec/query_diet/logger_spec.rb
@@ -5,9 +5,11 @@ describe QueryDiet::Logger do
   end
 
   def mock_realtime(seconds)
-    Benchmark.should_receive(:realtime).at_least(:once).and_wrap_original do |original_method, *args, &block|
-      original_method.call(*args, &block)
-      seconds
+    call_count = 0
+    Process.should_receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).at_least(:twice).and_wrap_original do
+      result = call_count.even? ? (call_count / 2) * seconds : ((call_count / 2) + 1) * seconds
+      call_count += 1
+      result
     end
   end
 


### PR DESCRIPTION
In Ruby 3.4+, the Benchmark constant is no longer reliably available
in gem contexts when loaded through Rails 8.1, causing `NameError:
uninitialized constant Benchmark`.

This replaces `Benchmark.realtime` with `Process.clock_gettime`, which:
- Is part of Ruby core and doesn't require loading (since ruby 2.x)
- Provides the same monotonic time measurement
- Returns elapsed time in seconds as a Float (identical to Benchmark.realtime)
- Maintains backward compatibility with all existing functionality

Fixes compatibility with:
- Ruby 3.4+
- Rails 8.1+

No behavior changes - Process.clock_gettime(Process::CLOCK_MONOTONIC)
is actually what Benchmark.realtime uses internally.